### PR TITLE
Move passwd to str and use crypt.mksalt() to generate salt #2564

### DIFF
--- a/src/rockstor/system/users.py
+++ b/src/rockstor/system/users.py
@@ -181,24 +181,27 @@ def usermod(username, passwd):
     # TODO: 'salt = crypt.mksalt()' # Python 3.3 onwards provides system best.
     # Salt starting "$6$" & of 19 chars signifies SHA-512 current system best.
     # Salt must contain only [./a-zA-Z0-9] chars (bar first 3 if len > 2)
-    salt_header = "$6$"  # SHA-512
-    rnd = random.SystemRandom()
-    salt = "".join(
-        [rnd.choice(string.ascii_letters + string.digits + "./") for _ in range(16)]
-    )
-    crypted_passwd = crypt.crypt(passwd.encode("utf8"), salt_header + salt)
+    # salt_header = "$6$"  # SHA-512
+    # rnd = random.SystemRandom()
+    # salt = "".join(
+    #     [rnd.choice(string.ascii_letters + string.digits + "./") for _ in range(16)]
+    # )
+    # crypted_passwd = crypt.crypt(passwd.encode("utf8"), salt_header + salt)
+    salt = crypt.mksalt()
+    crypted_passwd = crypt.crypt(passwd, salt)
     cmd = [USERMOD, "-p", crypted_passwd, username]
-    p = subprocess.Popen(
-        cmd,
-        shell=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        stdin=subprocess.PIPE,
-    )
-    out, err = p.communicate(input=None)
-    rc = p.returncode
-    if rc != 0:
-        raise CommandException(cmd, out, err, rc)
+    out, err, rc = run_command(cmd, log=True)
+    # p = subprocess.Popen(
+    #     cmd,
+    #     shell=False,
+    #     stdout=subprocess.PIPE,
+    #     stderr=subprocess.PIPE,
+    #     stdin=subprocess.PIPE,
+    # )
+    # out, err = p.communicate(input=None)
+    # rc = p.returncode
+    # if rc != 0:
+    #     raise CommandException(cmd, out, err, rc)
     return out, err, rc
 
 


### PR DESCRIPTION
After submitting first-login info, I get the following error:
```
            Traceback (most recent call last):
  File "/opt/rockstor/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception
    yield
  File "/opt/rockstor/src/rockstor/storageadmin/views/user.py", line 193, in post
    usermod(invar["username"], invar["password"])
  File "/opt/rockstor/src/rockstor/system/users.py", line 189, in usermod
    crypted_passwd = crypt.crypt(passwd.encode("utf8"), salt_header + salt)
  File "/usr/lib64/python3.6/crypt.py", line 47, in crypt
    return _crypt.crypt(word, salt)
TypeError: crypt() argument 1 must be str, not bytes
```

As we can see, it seems `crypt.crypt()` now needs a `str` and not a byte object. I thought I would give this one a shot and submit the changes as PR in case it helps.

This commit:

- removes the prior manual encoding to convert from `str` to `byte`
- implements the changes detailed in a listed TODO: switch to using `crypt.mksalt()` to generate the salt
- further simplifies this function by calling `system.run_command()` instead of manually calling `subprocess.Popen()` again

I've left the previous code commented out to ease comparison at first glance (without diff).

With this commit in, I can successfully submit the first login form and get to Rockstor's dashboard.