### PR TITLE
Move UDEVADM and SHUTDOWN definitions to runtime constants #2564

### DIFF
--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -426,15 +426,6 @@ TASK_SCHEDULER = {
 
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 
-# Setup OS specific command paths via 'which cmd' calls
-# N.B. this method will not work with an alias, ie in CentOS
-# which ls
-# alias ls='ls --color=auto'
-#         /usr/bin/ls
-# The following have been tested in CentOS, openSUSE Leap15, and Tumbleweed
-UDEVADM = subprocess.check_output(["which", "udevadm"]).rstrip()
-SHUTDOWN = subprocess.check_output(["which", "shutdown"]).rstrip()
-
 # Establish our OS base id, name, and version:
 # Use id for code path decisions. Others are for Web-UI display purposes.
 # Examples given are for CentOS Rockstor variant, Leap 15, and Tumblweed.

--- a/src/rockstor/system/constants.py
+++ b/src/rockstor/system/constants.py
@@ -30,3 +30,7 @@ UMOUNT = "/usr/bin/umount"
 USERMOD = "/usr/sbin/usermod"
 
 SYSTEMCTL = "/usr/bin/systemctl"
+
+# Works in Leap 15.4 (systemd-249.16-150400.8.28.3) and Tumbleweed (systemd-253.4-2.1)
+UDEVADM = "/usr/bin/udevadm"
+SHUTDOWN = "/sbin/shutdown"

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -35,7 +35,7 @@ from distutils.util import strtobool
 from django.conf import settings
 
 from system.exceptions import CommandException, NonBTRFSRootException
-from system.constants import SYSTEMCTL, MKDIR, RMDIR, MOUNT, UMOUNT, DEFAULT_MNT_DIR
+from system.constants import SYSTEMCTL, MKDIR, RMDIR, MOUNT, UMOUNT, DEFAULT_MNT_DIR, UDEVADM, SHUTDOWN
 
 logger = logging.getLogger(__name__)
 
@@ -52,10 +52,8 @@ HOSTNAMECTL = "/usr/bin/hostnamectl"
 LS = "/usr/bin/ls"
 LSBLK = "/usr/bin/lsblk"
 NMCLI = "/usr/bin/nmcli"
-SHUTDOWN = settings.SHUTDOWN
 SYSTEMD_ESCAPE = "/usr/bin/systemd-escape"
 SYSTEMD_DIR = "/usr/lib/systemd/system"
-UDEVADM = settings.UDEVADM
 WIPEFS = "/usr/sbin/wipefs"
 RTC_WAKE_FILE = "/sys/class/rtc/rtc0/wakealarm"
 PING = "/usr/bin/ping"


### PR DESCRIPTION
@phillxnet, this is another pull-request that compiles changes we discussed, hoping it'll help.

This PR moves the definitions of UDEVADM and SHUTDOWN from our Django settings to run time in the already existing `system.constants.py`.

Note that in Leap 15.4, we have:
```
rockdev:/opt/rockstor # which udevadm
/sbin/udevadm
```
But this is just a symlink to `/usr/bin/udevadm`:
```
rockdev:/opt/rockstor # ls -lah /sbin/udevadm
lrwxrwxrwx 1 root root 16 Apr 28 11:09 /sbin/udevadm -> /usr/bin/udevadm
```

`/usr/bin/udevadm` is also the correct path in Tumbleweed, so using this path covers both Leap and Tumbleweed.

To test:
- the branch builds successfully
- `rockstor-bootstrap` starts successfully
- I can access the Rockstor first login UI.

Hope this helps,